### PR TITLE
Add StatKeeperLite highlightAll

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -56,6 +56,10 @@ function highlightTags(element) {
     });
 }
 
+function highlightAll() {
+    document.querySelectorAll('#chat .mes_text').forEach(highlightTags);
+}
+
 function formatStats() {
     ensurePlayer();
     const p = store().player;
@@ -124,6 +128,8 @@ eventSource.on(event_types.USER_MESSAGE_RENDERED, (id) => {
     const el = document.querySelector(`#chat [mesid="${id}"] .mes_text`);
     highlightTags(el);
 });
+eventSource.on(event_types.APP_READY, highlightAll);
+eventSource.on(event_types.CHAT_CHANGED, highlightAll);
 
 SlashCommandParser.addCommandObject(
     SlashCommand.fromProps({


### PR DESCRIPTION
## Summary
- add `highlightAll()` helper to StatKeeperLite extension
- register `highlightAll()` for `APP_READY` and `CHAT_CHANGED` events

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*