### PR TITLE
Add processed message reset on chat change

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -130,6 +130,7 @@ eventSource.on(event_types.USER_MESSAGE_RENDERED, (id) => {
 });
 eventSource.on(event_types.APP_READY, highlightAll);
 eventSource.on(event_types.CHAT_CHANGED, highlightAll);
+eventSource.on(event_types.CHAT_CHANGED, () => processedMessages.clear());
 
 SlashCommandParser.addCommandObject(
     SlashCommand.fromProps({


### PR DESCRIPTION
## Summary
- clear processed messages cache when a new chat is loaded so tags reprocess

## Testing
- `npm run lint`