### PR TITLE
Add HUD for StatKeeper-Lite

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -4,6 +4,9 @@ import {
     eventSource,
     event_types,
     saveSettingsDebounced,
+    characters,
+    this_chid,
+    getThumbnailUrl,
 } from '../../../script.js';
 import { extension_settings } from '../../extensions.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
@@ -36,10 +39,23 @@ function d6_13() {
 
 function ensurePlayer() {
     const st = store();
-    if (st.player) return;
-    st.player = { STR: d6_13(), DEX: d6_13(), INT: d6_13(), MP: 20, MaxMP: 20 };
-    st.player.MaxHP = st.player.HP =
-        16 + ((st.player.STR + st.player.DEX) >> 2);
+    st.settings ??= {};
+    if (!st.player) {
+        st.player = {
+            STR: d6_13(),
+            DEX: d6_13(),
+            INT: d6_13(),
+            MP: 20,
+            MaxMP: 20,
+            inventory: [],
+            sceneObjects: [],
+        };
+        st.player.MaxHP = st.player.HP =
+            16 + ((st.player.STR + st.player.DEX) >> 2);
+    } else {
+        st.player.inventory ??= [];
+        st.player.sceneObjects ??= [];
+    }
     save();
 }
 
@@ -64,6 +80,70 @@ function formatStats() {
     ensurePlayer();
     const p = store().player;
     return `[[SYSTEM]] HP ${p.HP}/${p.MaxHP}  •  MP ${p.MP}/${p.MaxMP}  •  STR ${p.STR}  DEX ${p.DEX}  INT ${p.INT}`;
+}
+
+let lastHp = 0;
+function updateHUD() {
+    ensurePlayer();
+    const p = store().player;
+    const hud = document.getElementById('skl-hud');
+    if (!hud) return;
+    const char = characters?.[this_chid];
+    if (char) {
+        document.getElementById('skl-avatar').src = getThumbnailUrl('avatar', char.avatar);
+        document.getElementById('skl-name').textContent = char.name;
+    }
+    const hp = document.getElementById('skl-hp');
+    const mp = document.getElementById('skl-mp');
+    if (hp) {
+        if (lastHp > p.HP) {
+            hp.classList.add('dmg-flash');
+            setTimeout(() => hp.classList.remove('dmg-flash'), 600);
+        }
+        hp.max = p.MaxHP;
+        hp.value = p.HP;
+    }
+    lastHp = p.HP;
+    if (mp) {
+        mp.max = p.MaxMP;
+        mp.value = p.MP;
+    }
+    document.getElementById('skl-stats').textContent = `STR ${p.STR}  DEX ${p.DEX}  INT ${p.INT}`;
+    document.getElementById('skl-equipped').textContent = p.equipped ? `Equipped: ${p.equipped}` : '';
+    const invUl = document.querySelector('#skl-inv ul');
+    invUl.innerHTML = '';
+    p.inventory.forEach(it => {
+        const li = document.createElement('li');
+        li.textContent = it;
+        invUl.appendChild(li);
+    });
+    document.querySelector('#skl-inv summary').textContent = `Inventory (${p.inventory.length})`;
+    const sceneUl = document.querySelector('#skl-scene ul');
+    sceneUl.innerHTML = '';
+    p.sceneObjects.forEach(it => {
+        const li = document.createElement('li');
+        li.textContent = it;
+        sceneUl.appendChild(li);
+    });
+    document.querySelector('#skl-scene summary').textContent = `Scene (${p.sceneObjects.length})`;
+}
+
+function injectHUD() {
+    if (document.getElementById('skl-hud')) return;
+    if (!document.getElementById('skl-style')) {
+        const link = document.createElement('link');
+        link.id = 'skl-style';
+        link.rel = 'stylesheet';
+        link.href = 'styles/extensions/statkeeper.css';
+        document.head.appendChild(link);
+    }
+    const div = document.createElement('div');
+    div.id = 'skl-hud';
+    div.innerHTML =
+        '<img id="skl-avatar"><div id="skl-name"></div><progress id="skl-hp" max="100" value="100"></progress><progress id="skl-mp" max="100" value="100"></progress><span id="skl-stats"></span><span id="skl-equipped"></span><details id="skl-inv"><summary>Inventory (0)</summary><ul></ul></details><details id="skl-scene"><summary>Scene (0)</summary><ul></ul></details>';
+    (document.querySelector('#sidebar') ?? document.body).prepend(div);
+    updateHUD();
+    console.log('[StatKeeper-HUD] ready');
 }
 
 function postSystemMessage(html) {
@@ -104,10 +184,15 @@ function applyTagsFromMessage(text) {
         if (kind === 'HP') pool.HP = clamp((pool.HP ?? 0) + delta, pool.MaxHP);
         else pool.MP = clamp((pool.MP ?? 0) + delta, pool.MaxMP);
     }
-    if (playerChanged)
-        postSystemMessage(
-            `[[SYSTEM]] HP ${st.player.HP}/${st.player.MaxHP}  •  MP ${st.player.MP}/${st.player.MaxMP}`,
-        );
+    if (playerChanged) {
+        if (st.settings?.showSystemLines) {
+            postSystemMessage(
+                `[[SYSTEM]] HP ${st.player.HP}/${st.player.MaxHP}  •  MP ${st.player.MP}/${st.player.MaxMP}`,
+            );
+        }
+        updateHUD();
+        window.dispatchEvent(new CustomEvent('statkeeper:update', { detail: st.player }));
+    }
     save();
 }
 
@@ -128,7 +213,10 @@ eventSource.on(event_types.USER_MESSAGE_RENDERED, (id) => {
     const el = document.querySelector(`#chat [mesid="${id}"] .mes_text`);
     highlightTags(el);
 });
-eventSource.on(event_types.APP_READY, highlightAll);
+eventSource.on(event_types.APP_READY, () => {
+    highlightAll();
+    injectHUD();
+});
 eventSource.on(event_types.CHAT_CHANGED, highlightAll);
 eventSource.on(event_types.CHAT_CHANGED, () => processedMessages.clear());
 
@@ -144,5 +232,54 @@ SlashCommandParser.addCommandObject(
     }),
 );
 
+SlashCommandParser.addCommandObject(
+    SlashCommand.fromProps({
+        name: 'inv',
+        callback: () => {
+            ensurePlayer();
+            const p = store().player;
+            postSystemMessage(`[SYSTEM] Inventory: ${p.inventory.join(', ') || 'empty'}`);
+            return '';
+        },
+        helpString: 'List inventory items',
+    }),
+);
+
+SlashCommandParser.addCommandObject(
+    SlashCommand.fromProps({
+        name: 'scene',
+        callback: () => {
+            ensurePlayer();
+            const p = store().player;
+            postSystemMessage(`[SYSTEM] Scene: ${p.sceneObjects.join(', ') || 'none'}`);
+            return '';
+        },
+        helpString: 'List scene objects',
+    }),
+);
+
+SlashCommandParser.addCommandObject(
+    SlashCommand.fromProps({
+        name: 'take',
+        callback: (_, item) => {
+            ensurePlayer();
+            const p = store().player;
+            item = (item ?? '').trim();
+            const idx = p.sceneObjects.indexOf(item);
+            if (idx >= 0) {
+                p.sceneObjects.splice(idx, 1);
+                p.inventory.push(item);
+                updateHUD();
+                window.dispatchEvent(new CustomEvent('statkeeper:update', { detail: p }));
+                save();
+            } else {
+                postSystemMessage(`[SYSTEM] '${item}' not found`);
+            }
+            return '';
+        },
+        helpString: 'Take item from scene',
+        rawQuotes: true,
+    }),
+);
+
 ensurePlayer();
-console.log('[StatKeeper-Lite] ready');

--- a/public/styles/extensions/statkeeper.css
+++ b/public/styles/extensions/statkeeper.css
@@ -1,0 +1,12 @@
+#skl-hud {
+  background:#222;
+  padding:6px;
+  border-radius:4px;
+  color:#eee;
+  font-size:13px;
+  max-width:180px;
+}
+#skl-hud img{width:100%;border-radius:4px;}
+#skl-hud progress{width:100%;}
+.dmg-flash{animation:dmgflash 0.6s ease;}
+@keyframes dmgflash{0%{background:#a00;}100%{background:inherit;}}


### PR DESCRIPTION
## Summary
- create persistent HUD sidebar for StatKeeper
- track inventory and scene objects with new slash commands
- stop automatic stat spam in chat
- broadcast `statkeeper:update` events
- add dark theme styling with damage flash animation

## Testing
- `npm run lint`