### PR TITLE
Add scene list parsing to Stat Keeper

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -206,6 +206,39 @@ function applyTagsFromMessage(text) {
     save();
 }
 
+function scanSceneList(text) {
+    if (!text) return;
+    ensurePlayer();
+    const lines = String(text).split(/\r?\n/);
+    let start = -1;
+    for (let i = 0; i < lines.length; i++) {
+        if (/^\s*Scene(?: objects)?:\s*$/i.test(lines[i].trim())) {
+            start = i + 1;
+            break;
+        }
+    }
+    if (start === -1) return;
+    const bulletRe = /^\s*[\u2022*-]\s*(.+)$/;
+    const p = store().player;
+    let changed = false;
+    for (let i = start; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.trim()) break;
+        const m = bulletRe.exec(line);
+        if (!m) break;
+        let item = m[1].trim().replace(/[.,;!?]+$/g, '').trim();
+        if (item && !p.sceneObjects.includes(item)) {
+            p.sceneObjects.push(item);
+            changed = true;
+        }
+    }
+    if (changed) {
+        updateHUD();
+        window.dispatchEvent(new CustomEvent('statkeeper:update', { detail: p }));
+        save();
+    }
+}
+
 function handleRenderedMessage(id) {
     const mes = chat[id];
     if (!mes) return;
@@ -214,6 +247,7 @@ function handleRenderedMessage(id) {
     if (processedMessages.has(id)) return;
     if (!mes.is_user) {
         applyTagsFromMessage(mes.mes);
+        scanSceneList(mes.mes);
         processedMessages.add(id);
     }
 }


### PR DESCRIPTION
## Summary
- update stat-keeper-lite to read bullet lists for scene objects
- update HUD when new scene objects are parsed

## Testing
- `npm run lint`
- `npm test --prefix tests` *(fails: jest not found)*