### PR TITLE
Fix StatKeeperLite custom hide classes

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -80,10 +80,14 @@ function highlightTags(element) {
 }
 
 function hideSyncMessages() {
-    document.querySelectorAll('#chat .mes_text .skl-hidden').forEach((span) => {
-        const mes = span.closest('.mes');
-        if (mes) mes.classList.add('skl-hidden-message');
-    });
+    document
+        .querySelectorAll(
+            '#chat .mes_text .skl-hidden, #chat .mes_text .custom-skl-hidden',
+        )
+        .forEach((span) => {
+            const mes = span.closest('.mes');
+            if (mes) mes.classList.add('skl-hidden-message', 'custom-skl-hidden-message');
+        });
 }
 
 function highlightAll() {

--- a/public/scripts/extensions/stat-keeper-lite/style.css
+++ b/public/scripts/extensions/stat-keeper-lite/style.css
@@ -18,6 +18,14 @@
   display: none !important;
 }
 
+.custom-skl-hidden {
+  display: none !important;
+}
+
 .skl-hidden-message {
+  display: none !important;
+}
+
+.custom-skl-hidden-message {
   display: none !important;
 }


### PR DESCRIPTION
## Summary
- support custom-skl-hidden in StatKeeperLite
- add CSS for `.custom-skl-hidden` and `.custom-skl-hidden-message`

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*