### PR TITLE
Fix StatKeeperLite sync broadcast and item parsing

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -7,6 +7,7 @@ import {
     characters,
     this_chid,
     getThumbnailUrl,
+    sendMessageAsUser,
 } from '../../../script.js';
 import { extension_settings } from '../../extensions.js';
 import { SlashCommand } from '../../slash-commands/SlashCommand.js';
@@ -66,6 +67,7 @@ function clamp(v, m) {
 function canonical(item) {
     return String(item ?? '')
         .toLowerCase()
+        .replace(/^(?:a|an|the)\s+/, '')
         .split(/[,(–]/)[0]
         .trim();
 }
@@ -80,10 +82,22 @@ function highlightTags(element) {
 }
 
 function hideSyncMessages() {
-    document.querySelectorAll('#chat .mes_text .skl-hidden').forEach((span) => {
-        const mes = span.closest('.mes');
-        if (mes) mes.classList.add('skl-hidden-message');
-    });
+    document
+        .querySelectorAll(
+            '#chat .mes_text .skl-hidden, #chat .mes_text .custom-skl-hidden',
+        )
+        .forEach((span) => {
+            const mes = span.closest('.mes');
+            if (!mes) return;
+            const mesText = mes.querySelector('.mes_text');
+            const onlyHidden =
+                mesText &&
+                mesText.children.length === 1 &&
+                mesText.textContent.trim() === span.textContent.trim();
+            if (onlyHidden) {
+                mes.classList.add('skl-hidden-message', 'custom-skl-hidden-message');
+            }
+        });
 }
 
 function highlightAll() {
@@ -406,7 +420,7 @@ SlashCommandParser.addCommandObject(
 SlashCommandParser.addCommandObject(
     SlashCommand.fromProps({
         name: 'take',
-        callback: (_, item) => {
+        callback: async (_, item) => {
             ensurePlayer();
             const p = store().player;
             const itemName = typeof item === 'string' ? item.trim() : '';
@@ -421,6 +435,8 @@ SlashCommandParser.addCommandObject(
                 window.dispatchEvent(new CustomEvent('statkeeper:update', { detail: p }));
                 save();
                 pushSync(p.sceneObjects, p.inventory);
+                await sendMessageAsUser(`I take ${fullText}`);
+                postSystemMessage('[SYSTEM] ' + fullText + ' taken.');
             } else {
                 postSystemMessage(`[SYSTEM] '${itemName}' not found`);
             }
@@ -435,7 +451,7 @@ SlashCommandParser.addCommandObject(
     SlashCommand.fromProps({
         name: 'drop',
         aliases: ['give', 'discard'],
-        callback: (_, arg) => {
+        callback: async (_, arg) => {
             ensurePlayer();
             const p = store().player;
             const want = canonical(typeof arg === 'string' ? arg.trim() : '');
@@ -448,6 +464,7 @@ SlashCommandParser.addCommandObject(
                 updateHUD();
                 save();
                 pushSync(p.sceneObjects, p.inventory);
+                await sendMessageAsUser(`I drop ${fullText}`);
                 postSystemMessage('[SYSTEM] ' + fullText + ' dropped.');
             } else {
                 postSystemMessage(`[SYSTEM] '${arg}' not in inventory`);

--- a/public/scripts/extensions/stat-keeper-lite/style.css
+++ b/public/scripts/extensions/stat-keeper-lite/style.css
@@ -18,6 +18,14 @@
   display: none !important;
 }
 
+.custom-skl-hidden {
+  display: none !important;
+}
+
 .skl-hidden-message {
+  display: none !important;
+}
+
+.custom-skl-hidden-message {
   display: none !important;
 }


### PR DESCRIPTION
## Summary
- include `sendMessageAsUser` in StatKeeperLite extension
- skip leading articles when matching item names
- only hide entire sync messages if the hidden span is the only content
- broadcast `/take` and `/drop` actions as user messages

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*