### PR TITLE
Update stat keeper HUD style

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/style.css
+++ b/public/scripts/extensions/stat-keeper-lite/style.css
@@ -1,10 +1,20 @@
 #skl-hud {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
   background:#222;
   padding:6px;
   border-radius:4px;
   color:#eee;
   font-size:13px;
+  width:180px;
   max-width:180px;
+  max-height:60vh;
+  overflow-y:auto;
+}
+#skl-name {
+  word-break: break-word;
 }
 #skl-hud img{width:100%;border-radius:4px;}
 #skl-hud progress{width:100%;}

--- a/public/styles/extensions/statkeeper.css
+++ b/public/styles/extensions/statkeeper.css
@@ -1,10 +1,20 @@
 #skl-hud {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
   background:#222;
   padding:6px;
   border-radius:4px;
   color:#eee;
   font-size:13px;
+  width:180px;
   max-width:180px;
+  max-height:60vh;
+  overflow-y:auto;
+}
+#skl-name {
+  word-break: break-word;
 }
 #skl-hud img{width:100%;border-radius:4px;}
 #skl-hud progress{width:100%;}


### PR DESCRIPTION
## Summary
- fix Stat Keeper HUD positioning and size constraints
- wrap long character names in the HUD

## Testing
- `npm run lint`
- `npm test --prefix tests` *(fails: jest not found)*