### PR TITLE
Add item highlighting to Stat Keeper Lite

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -116,6 +116,29 @@ function highlightTags(element) {
     });
 }
 
+function escapeRegExp(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function highlightItemTerms(element) {
+    if (!element) return;
+    if (element.querySelector('.skl-item')) return;
+    ensurePlayer();
+    const p = store().player;
+    if (!p.sceneObjects?.length) return;
+    let html = element.innerHTML;
+    for (const it of p.sceneObjects) {
+        if (!it) continue;
+        const tagMatch = /(weapon|consumable|container|quest|npc)/i.exec(it);
+        const type = tagMatch ? tagMatch[1].toLowerCase() : 'scenery';
+        const label = it.replace(/\(.*?\)/, '').trim();
+        if (!label) continue;
+        const re = new RegExp(`\\b${escapeRegExp(label)}\\b`, 'gi');
+        html = html.replace(re, (m) => `<span class="skl-item skl-${type}">${m}</span>`);
+    }
+    element.innerHTML = html;
+}
+
 function hideSyncMessages() {
     document
         .querySelectorAll(
@@ -443,6 +466,7 @@ function handleRenderedMessage(id) {
     if (!mes) return;
     const el = document.querySelector(`#chat [mesid="${id}"] .mes_text`);
     highlightTags(el);
+    highlightItemTerms(el);
     hideSyncMessages();
     if (processedMessages.has(id)) return;
     if (!mes.is_user) {
@@ -465,6 +489,7 @@ eventSource.on(event_types.USER_MESSAGE_RENDERED, (id) => {
     }
     const el = document.querySelector(`#chat [mesid="${id}"] .mes_text`);
     highlightTags(el);
+    highlightItemTerms(el);
     hideSyncMessages();
 });
 eventSource.on(event_types.APP_READY, () => {

--- a/public/scripts/extensions/stat-keeper-lite/style.css
+++ b/public/scripts/extensions/stat-keeper-lite/style.css
@@ -39,3 +39,12 @@
 .custom-skl-hidden-message {
   display: none !important;
 }
+
+/* item highlighting */
+.skl-item{padding:0 2px;border-radius:2px;font-weight:600;}
+.skl-weapon{color:#FFA64C;background:rgba(255,166,76,.15);}
+.skl-consumable{color:#5AFF5A;background:rgba(90,255,90,.10);}
+.skl-container{color:#4FC3F7;background:rgba(79,195,247,.12);}
+.skl-quest{color:#FFD700;background:rgba(255,215,0,.18);font-weight:bold;}
+.skl-npc{color:#C792EA;}
+.skl-scenery{color:#B0BEC5;}


### PR DESCRIPTION
## Summary
- highlight scene object terms when they appear in chat
- add CSS styles for highlighted item types

## Testing
- `npm test` *(fails: missing script)*