### PR TITLE
Fix inventory sync in Stat Keeper Lite

### DIFF
--- a/public/scripts/extensions/stat-keeper-lite/index.js
+++ b/public/scripts/extensions/stat-keeper-lite/index.js
@@ -16,6 +16,7 @@ import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
 const SLOT = 'StatKeeperLite';
 const TAG = /\[(HP|MP|MANA)\s*([+-]\d+)(?:\s+([\w\s'-]+))?\]/gi;
 const ACTION_RE = /<span class="skl-hidden">ACTION\|([^<]+)<\/span>/gi;
+const SYNC_RE = /<span class="skl-hidden">SYNC\|([^<]+)<\/span>/i;
 const colorFor = (k, n) =>
     k === 'HP'
         ? n < 0
@@ -110,6 +111,7 @@ window.StatKeeperDice = rollDice;
 function highlightTags(element) {
     if (!element) return;
     if (element.querySelector('.sklTag')) return;
+    if (element.querySelector('.skl-hidden')) return;
     element.innerHTML = element.innerHTML.replace(TAG, (m, k, n) => {
         const val = Number(n);
         return `<span class="sklTag" style="color:${colorFor(k.toUpperCase(), val)}">${m}</span>`;
@@ -123,6 +125,7 @@ function escapeRegExp(str) {
 function highlightItemTerms(element) {
     if (!element) return;
     if (element.querySelector('.skl-item')) return;
+    if (element.querySelector('.skl-hidden')) return;
     ensurePlayer();
     const p = store().player;
     if (!p.sceneObjects?.length) return;
@@ -473,6 +476,22 @@ function handleRenderedMessage(id) {
     hideSyncMessages();
     if (processedMessages.has(id)) return;
     if (!mes.is_user) {
+        SYNC_RE.lastIndex = 0;
+        const syncMatch = SYNC_RE.exec(mes.mes);
+        if (syncMatch) {
+            try {
+                const data = JSON.parse(syncMatch[1]);
+                ensurePlayer();
+                const p = store().player;
+                if (Array.isArray(data.scene)) p.sceneObjects = [...data.scene];
+                if (Array.isArray(data.inv)) p.inventory = [...data.inv];
+                updateHUD();
+                window.dispatchEvent(new CustomEvent('statkeeper:update', { detail: p }));
+                save();
+            } catch (err) {
+                console.error('[StatKeeperLite] Failed to parse SYNC data', err);
+            }
+        }
         applyTagsFromMessage(mes.mes);
         scanSceneList(mes.mes);
         ACTION_RE.lastIndex = 0;


### PR DESCRIPTION
## Summary
- parse `SYNC` tags in Stat Keeper Lite extension so GM updates move items into players' inventories
- ensure highlighting does not corrupt `SYNC` messages by skipping `.skl-hidden` spans

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: missing test script)*
- `npm test` in `/tests` *(fails: jest not found)*