### PR TITLE
Fix Roller extension import paths

### DIFF
--- a/public/scripts/extensions/roller/index.js
+++ b/public/scripts/extensions/roller/index.js
@@ -1,5 +1,7 @@
-import { eventSource, event_types, addOneMessage } from '../../../../script.js';
-import * as CoreState from '../../core-state/index.js';
+// Imported from /public/script.js
+import { eventSource, event_types } from '../../../script.js';
+// Core state utilities in /public/scripts/extensions/core-state
+import * as CoreState from '../core-state/index.js';
 
 const TxStore = {};
 


### PR DESCRIPTION
## Summary
- fix relative imports for Roller extension after directory move
- add comments clarifying imported modules
- ensure file ends with newline

## Testing
- `npm run lint`