### PR TITLE
Fix roller modHP patch argument order

### DIFF
--- a/public/scripts/extensions/roller/index.js
+++ b/public/scripts/extensions/roller/index.js
@@ -64,11 +64,7 @@ function applyPatch(patch) {
         console.warn('[Roller] unknown verb', patch.verb);
         return;
     }
-    const args = [];
-    if (patch.target !== undefined) args.push(patch.target);
-    if (patch.delta !== undefined) args.push(patch.delta);
-    if (patch.item !== undefined) args.push(patch.item);
-    fn(...args);
+    fn(patch.target, patch.delta, patch.item);
 }
 
 function invert(patch) {


### PR DESCRIPTION
## Summary
- ensure applyPatch passes args in correct order so CoreState functions receive the proper parameters

## Testing
- `git status --short`