### PR TITLE
Fix eventSource import for Tagger extension

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -1,7 +1,5 @@
 import * as CoreState from '../core-state/index.js';
-
-// Access the global event source provided by the build
-const { eventSource, event_types } = window;
+import { eventSource, event_types } from '../../../script.js';
 
 // Resolve the player name from the current context at load time
 /** @type {any} */


### PR DESCRIPTION
## Summary
- fix Tagger extension to import `eventSource` from script.js

## Testing
- `npm run lint`