### PR TITLE
Add RuleVault extension

### DIFF
--- a/extensions/rulevault/index.js
+++ b/extensions/rulevault/index.js
@@ -1,0 +1,94 @@
+import { chat, eventSource, event_types } from '../../public/script.js';
+import * as CoreState from '../../public/scripts/extensions/core-state/index.js';
+
+function personaName(){
+  return SillyTavern?.getContext?.().character?.name
+      || SillyTavern?.getContext?.().persona?.name
+      || 'Player';
+}
+
+function parseItems(str){
+  if(!str) return [];
+  const clean = str.replace(/^\[|\]$/g,'');
+  return clean.split(',').map(s=>s.trim()).filter(Boolean);
+}
+
+function coreSetScene(items){
+  if(typeof CoreState.setScene === 'function'){
+    CoreState.setScene(items);
+  }else if(typeof CoreState.updateSceneObjects === 'function'){
+    CoreState.updateSceneObjects(items);
+  }else{
+    const ctx = SillyTavern?.getContext?.() ?? {};
+    const chatId = ctx.chat?.id || 'default';
+    const key = `st.rpg.coreState.v1::${chatId}`;
+    const state = CoreState.getState();
+    state.sceneObjects = items;
+    try{ localStorage.setItem(key, JSON.stringify(state)); }catch(err){ console.error('[RuleVault] save failed', err); }
+  }
+  window.dispatchEvent(new CustomEvent('sceneUpdate', { detail:{ items } }));
+}
+
+function handleCommand(cmd){
+  if(!cmd) return;
+  if(cmd.verb === 'setScene'){
+    const items = parseItems(cmd.args.items);
+    coreSetScene(items);
+  }else if(cmd.verb === 'addItem'){
+    if(cmd.args.item){
+      CoreState.addItem(personaName(), cmd.args.item);
+      window.dispatchEvent(new CustomEvent('itemAdd', { detail:{ item: cmd.args.item } }));
+    }
+  }else if(cmd.verb === 'removeItem'){
+    if(cmd.args.item){
+      CoreState.removeItem(personaName(), cmd.args.item);
+      window.dispatchEvent(new CustomEvent('itemRemove', { detail:{ item: cmd.args.item } }));
+    }
+  }
+}
+
+function parseControl(line){
+  if(!line.startsWith('::')) return null;
+  const m = /^::(\w+)\s*(.*)$/.exec(line.trim());
+  if(!m) return null;
+  const verb = m[1];
+  const argStr = m[2];
+  const args = {};
+  argStr.split(/\s+/).forEach(part=>{
+    const [k,v] = part.split('=');
+    if(k) args[k] = v;
+  });
+  return { verb, args };
+}
+
+function onMessage(id){
+  const mes = chat?.[id];
+  if(!mes || mes.is_user) return;
+  const lines = String(mes.mes||'').split(/\r?\n/);
+  if(!lines.length) return;
+  const last = lines[lines.length-1].trim();
+  if(!last.startsWith('::')) return;
+  const cmd = parseControl(last);
+  lines.pop();
+  mes.mes = lines.join('\n');
+  handleCommand(cmd);
+}
+
+function init(){
+  eventSource.on(event_types.MESSAGE_RECEIVED, onMessage);
+}
+
+if(document.readyState !== 'loading') init();
+else document.addEventListener('DOMContentLoaded', init, { once:true });
+
+export {};
+
+/* ===== RuleVault smoke test =====
+CoreState.clearState();
+onMessage(chat.push({is_user:false,mes:"::setScene items=[Sword,Shield]"})-1);
+console.assert(CoreState.getState().sceneObjects.includes('Sword'), 'scene set');
+let fired=false;window.addEventListener('itemAdd',()=>fired=true,{once:true});
+onMessage(chat.push({is_user:false,mes:"::addItem target=Player item=Sword"})-1);
+console.assert(CoreState.getState().characters[personaName()].inventory.includes('Sword'),'add');
+console.assert(fired,'event fired');
+*/


### PR DESCRIPTION
## Summary
- introduce RuleVault extension that parses control lines from assistant messages
- support commands: `setScene`, `addItem`, and `removeItem`

## Testing
- `git status --short`