### PR TITLE
Add RuleVault scene & inventory management

### DIFF
--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -74,10 +74,10 @@ function handleCommand(cmd){
             const target = cmd.args.target || personaName();
             if(target.toLowerCase() === 'scene'){
                 removeSceneItem(cmd.args.item);
+                window.dispatchEvent(new CustomEvent('itemRemove', { detail:{ item: cmd.args.item } }));
             }else{
-                CoreState.removeItem(target, cmd.args.item);
+                dropItem(target, cmd.args.item);
             }
-            window.dispatchEvent(new CustomEvent('itemRemove', { detail:{ item: cmd.args.item } }));
         }
     }else if(cmd.verb === 'consumeItem'){
         if(cmd.args.item){
@@ -85,6 +85,15 @@ function handleCommand(cmd){
             CoreState.removeItem(target, cmd.args.item);
             window.dispatchEvent(new CustomEvent('itemRemove', { detail:{ item: cmd.args.item } }));
         }
+    }else if(cmd.verb === 'modHP'){
+        const target = cmd.args.target || personaName();
+        const amount = parseInt(cmd.args.amount, 10) || 0;
+        const reason = cmd.args.reason;
+        CoreState.modHP(target, amount, reason);
+    }else if(cmd.verb === 'modMP'){
+        const target = cmd.args.target || personaName();
+        const amount = parseInt(cmd.args.amount, 10) || 0;
+        CoreState.modMP(target, amount);
     }else if(cmd.verb === 'dropItem'){
         if(cmd.args.item){
             const target = cmd.args.target || personaName();

--- a/public/scripts/slash-commands.js
+++ b/public/scripts/slash-commands.js
@@ -2363,6 +2363,27 @@ export function initDefaultSlashCommands() {
         helpString: 'Copies the provided text to the OS clipboard. Returns an empty string.',
     }));
 
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'clearscene',
+        callback: clearSceneCallback,
+        helpString: 'Removes all items from the current scene.',
+    }));
+
+    SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+        name: 'clearinv',
+        callback: clearInventoryCallback,
+        namedArgumentList: [
+            SlashCommandNamedArgument.fromProps({
+                name: 'target',
+                description: 'character name whose inventory will be cleared',
+                typeList: [ARGUMENT_TYPE.STRING],
+                enumProvider: commonEnumProviders.characters('character'),
+                isRequired: false,
+            }),
+        ],
+        helpString: 'Clears the inventory of the specified or current character.',
+    }));
+
     registerVariableCommands();
 }
 
@@ -3768,6 +3789,24 @@ async function setNarratorName(_, text) {
     chat_metadata[NARRATOR_NAME_KEY] = name;
     toastr.info(`System narrator name set to ${name}`);
     await saveChatConditional();
+    return '';
+}
+
+async function clearSceneCallback() {
+    if (window.CoreState?.setScene) {
+        window.CoreState.setScene([]);
+    }
+    return '';
+}
+
+async function clearInventoryCallback(args) {
+    if (!window.CoreState) return '';
+    const target = args?.target || window.CoreState.playerName;
+    const state = window.CoreState.getState();
+    const items = state.characters?.[target]?.inventory || [];
+    for (const item of items) {
+        window.CoreState.removeItem(target, item);
+    }
     return '';
 }
 


### PR DESCRIPTION
## Summary
- fix RuleVault `removeItem` so dropped items return to the scene
- add `modHP` and `modMP` verbs to RuleVault
- introduce `/clearscene` and `/clearinv` slash commands for testing

## Testing
- `npm test` *(fails: jest not found)*