### PR TITLE
Implement RuleVault strict toggle and fix scene replacement

### DIFF
--- a/default/content/settings.json
+++ b/default/content/settings.json
@@ -379,6 +379,9 @@
             "voicMapText": "",
             "voiceMap": {}
         },
+        "ruleVault": {
+            "strict": true
+        },
         "cfg": {
             "global": {
                 "guidance_scale": 1,

--- a/public/scripts/extensions.js
+++ b/public/scripts/extensions.js
@@ -201,6 +201,9 @@ export const extension_settings = {
     rvc: {},
     hypebot: {},
     vectors: {},
+    ruleVault: {
+        strict: true,
+    },
     variables: {
         global: {},
     },

--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -8,8 +8,9 @@ import {
 } from '../../slash-commands/SlashCommandArgument.js';
 import { commonEnumProviders } from '../../slash-commands/SlashCommandCommonEnumsProvider.js';
 import { debounce } from '../../utils.js';
+import { extension_settings } from '../../extensions.js';
 
-const STRICT = window.RuleVault?.strict === true || window.RuleVaultStrict === true;
+let STRICT = true;
 
 function canon(id){
     return String(id || '').toLowerCase().replace(/[^a-z0-9]/g, '');
@@ -94,8 +95,10 @@ const saveSceneDebounced = debounce(() => {
 function coreSetScene(items){
     const canonItems = [...new Set(items.map(canon))];
     if(typeof CoreState.setScene === 'function'){
-        CoreState.setScene(canonItems);
-    }else if(typeof CoreState.updateSceneObjects === 'function'){
+        CoreState.setScene(canonItems); // event dispatched inside
+        return;
+    }
+    if(typeof CoreState.updateSceneObjects === 'function'){
         CoreState.updateSceneObjects(canonItems);
     }else{
         const state = CoreState.getState();
@@ -386,6 +389,7 @@ function onMessage(id){
 }
 
 function init(){
+    STRICT = extension_settings?.ruleVault?.strict !== false;
     eventSource.on(event_types.MESSAGE_RECEIVED, onMessage);
 
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({

--- a/public/scripts/extensions/rulevault/settingsSchema.json
+++ b/public/scripts/extensions/rulevault/settingsSchema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "strict": { "type": "boolean", "default": true }
+  }
+}


### PR DESCRIPTION
## Summary
- add configurable strict mode for RuleVault
- update extension settings defaults
- ensure setScene fully overwrites scene state
- expose settings schema for RuleVault extension

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*