### PR TITLE
Fix RuleVault strict mode assignment

### DIFF
--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -178,8 +178,7 @@ function rulevaultSlash(_, sub, state){
     if(String(sub).toLowerCase() === 'strict'){
         const enable = String(state).toLowerCase() === 'on';
         STRICT = enable;
-        extension_settings.ruleVault = extension_settings.ruleVault || {};
-        extension_settings.ruleVault.strict = enable;
+        extension_settings.ruleVault = { strict: enable };
         saveSettingsDebounced();
         assistantBubble(enable ? '*Strict mode enabled*' : '*Strict mode disabled*');
     }


### PR DESCRIPTION
## Summary
- fix assignment of `ruleVault.strict` in RuleVault extension

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*