### PR TITLE
Fix RuleVault self-test command

### DIFF
--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -574,7 +574,7 @@ function init(){
     }));
 
     SlashCommandParser.addCommandObjectUnsafe(SlashCommand.fromProps({
-        name: '/selftest',
+        name: '/rulevault-selftest',
         callback: runSmokeTest,
         helpString: 'Run the RuleVault self-test.',
     }));


### PR DESCRIPTION
## Summary
- update RuleVault self-test command registration so `/selftest` no longer autocompletes to `//selftest`

## Testing
- `npm run lint`
