### PR TITLE
Remove duplicate scene commit in RuleVault

### DIFF
--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -388,7 +388,6 @@ function processPacket(cmds){
         assistantBubble(`*Unknown item: ${pending[0].raw}*`);
         return;
     }
-    coreSetScene([...stagedScene]);
     actions.forEach(fn=>fn());
 }
 


### PR DESCRIPTION
## Summary
- eliminate extra sceneUpdate caused by redundant commit

## Testing
- `npm test` *(fails: Missing script)*