### PR TITLE
Fix RuleVault self-test step 5 expectation

### DIFF
--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -491,7 +491,7 @@ async function runSmokeTest(){
         state = CoreState.getState();
         d = delta(before);
         const last = chat[chat.length - 1];
-        const bubble = chat.length === preLen + 1 && last?.extra?.type === system_message_types.ASSISTANT_MESSAGE;
+        const bubble = chat.length === preLen + 2 && last?.extra?.type === system_message_types.ASSISTANT_MESSAGE;
         console.assert(!state.characters[personaName()].inventory.includes('fakegem') && bubble, 'strict block');
         console.assert(d.sceneUpdate === 0 && d.itemAdd === 0 && d.itemRemove === 0, 'event count');
         if(state.characters[personaName()].inventory.includes('fakegem') || !bubble || d.sceneUpdate !== 0 || d.itemAdd !== 0 || d.itemRemove !== 0) throw new Error('strict mode block');


### PR DESCRIPTION
## Summary
- adjust RuleVault self-test to account for both the command message and the assistant bubble when strict mode blocks an unknown item

## Testing
- `npm test` *(fails: Missing script)*