### PR TITLE
Fix Tagger initial highlighting

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -57,7 +57,10 @@ function tagElement(el){
 }
 
 function highlightAll(){
-    document.querySelectorAll('#chat .mes_text').forEach(tagElement);
+    document.querySelectorAll('#chat .mes_text').forEach(el => {
+        autoBracket(el);
+        tagElement(el);
+    });
 }
 
 function setsFromState(){


### PR DESCRIPTION
## Summary
- ensure Tagger wraps messages with `autoBracket` before converting to `<span>`

## Testing
- `npm --prefix tests test` *(fails: jest not found)*