### PR TITLE
Fix sceneguard showWarn query

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -95,12 +95,11 @@ const inject = window.SillyTavern?.injectAssistant
     }
 
  function showWarn(id, text){
-    let messageEl = document.querySelector(`#chat [mesid="${id}"] .mes_text`);
-    if(!messageEl){
-        // fallback: use the message container itself
-        messageEl = document.querySelector(`#chat [mesid="${id}"]`);
-        if(!messageEl) return;
-    }
+    let messageEl = document.querySelector(`#chat [mesid="${id}"] .mes_text`)
+                 || document.querySelector(`#chat [mesid="${id}"]`)
+                 || document.querySelector('#chat');   // ← fallback for SelfTest
+
+    if (!messageEl) return;   // final guard
     removeWarn();
     const span = document.createElement('span');
     span.className = 'system-bubble sceneguard-warn';


### PR DESCRIPTION
## Summary
- correct fallback logic when finding a target element for SceneGuard warnings

## Testing
- `npm run lint` *(fails: 70 errors)*