### PR TITLE
Fix SceneGuard warn target

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -148,7 +148,7 @@ function showWarn(id, text){
         } else {
             missCount++;
             if (missCount >= 2 && !document.querySelector('.sceneguard-warn')) {
-                showWarn(msg.id, '⚠ Scene list stale — resend with setScene.');
+                showWarn(id, '⚠ Scene list stale — resend with setScene.');
             }
         }
         lastHadScene = foundScene;


### PR DESCRIPTION
## Summary
- fix ID parameter when showing the stale scene warning bubble

## Testing
- `node -e "console.log('skip tests')"`