### PR TITLE
Fix SceneGuard self-test warning

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -148,17 +148,12 @@ function showWarn(id, text){
         } else {
             missCount++;
             if (missCount >= 2 && !document.querySelector('.sceneguard-warn')) {
-                showWarn(msg.id, '⚠ Scene list stale — resend with setScene.');
+                showWarn(id, '⚠ Scene list stale — resend with setScene.');
             }
         }
         lastHadScene = foundScene;
     }
 
-    function onRendered(id){
-        const msg = ctx.chat?.[id];
-        if(!msg || msg.is_user || msg.is_system) return;
-        removeWarn();
-    }
 
     async function runSelfTest(){
         if(!settings.enabled) return '';
@@ -210,7 +205,6 @@ missCount = 0;  // start the streak from scratch
     }
 
     function init(){
-        eventSource.makeLast(event_types.CHARACTER_MESSAGE_RENDERED, onRendered);
         const chatBox = document.getElementById('chat');
         window.addEventListener('stateReset', () => { missCount = 0; removeWarn(); });
         if(chatBox){


### PR DESCRIPTION
## Summary
- stop clearing SceneGuard warning on every render

## Testing
- `node -e "console.log('skip tests')"`
