### PR TITLE
Improve SceneGuard self-test logging

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -100,6 +100,7 @@ function showWarn(id, text){
           document.querySelector(`#chat [mesid="${id}"]`)           ||
           document.querySelector('#chat');   // fallback (SelfTest)
     if (!target) return;
+    console.debug('[SceneGuard] showWarn', id, text);
     removeWarn();
     const span = document.createElement('span');
     span.className = 'system-bubble sceneguard-warn';
@@ -112,7 +113,7 @@ function showWarn(id, text){
         if(!id) return;
         const msg = ctx.chat?.[id];
         if(!msg || msg.is_user || msg.is_system) return;
-          const hiddenNodes = [...node.querySelectorAll('div[style]')]
+        const hiddenNodes = [...node.querySelectorAll('.mes_text div[style]')]
                     .filter(el => el.style.display === 'none');
         const hasCtrl = hiddenNodes.some(d => /::\s*setScene/i.test(d.textContent));
         const hidden = hiddenNodes.map(n=>n.textContent.trim()).reverse().find(t => /::\s*setScene/i.test(t));
@@ -142,6 +143,13 @@ function showWarn(id, text){
             foundScene = true;
         }
         const isValid = foundScene && missing.length === 0;
+        console.debug('[SceneGuard] processed node', {
+            id,
+            foundScene,
+            missing,
+            isValid,
+            missCountBefore: missCount,
+        });
         if (isValid) {
             missCount = 0;
             removeWarn();
@@ -190,6 +198,7 @@ missCount = 0;  // start the streak from scratch
         inject('A rat scurries past.', { name: 'SelfTest', italic: true });
         await tick();
         await tick();
+        console.debug('[SceneGuard self-test] step 4 warn count', document.querySelectorAll('.sceneguard-warn').length, 'missCount', missCount);
         assert(document.querySelectorAll('.sceneguard-warn').length === 1, 4);
 
         sendTurn('::setScene item=Rat', 'A [Rat] bares its teeth.');


### PR DESCRIPTION
## Summary
- add console debugging for SceneGuard extension
- log details of processed nodes
- log self-test step 4 warning state
- restrict hidden node search to `.mes_text` container

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: missing test script)*


------
https://chatgpt.com/codex/tasks/task_e_683a1bbc9ca88322bb4b8f616e80e8fc