### PR TITLE
Add CSS for SceneGuard warnings

### DIFF
--- a/public/scripts/extensions/scene-guard/manifest.json
+++ b/public/scripts/extensions/scene-guard/manifest.json
@@ -4,7 +4,7 @@
   "requires": [],
   "optional": [],
   "js": "index.js",
-  "css": "",
+  "css": "style.css",
   "author": "SillyTavern User",
   "version": "1.0.0",
   "homePage": "https://github.com/SillyTavern/SillyTavern"

--- a/public/scripts/extensions/scene-guard/style.css
+++ b/public/scripts/extensions/scene-guard/style.css
@@ -1,0 +1,6 @@
+.system-bubble.sceneguard-warn {
+    color: var(--warning);
+    font-style: italic;
+    display: block;
+    margin: 4px 0;
+}


### PR DESCRIPTION
## Summary
- style SceneGuard warning bubble so it's visible in chat
- register the CSS file in the extension manifest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a35773f6c83228aecd13849572989