### PR TITLE
Fix SceneGuard warning reappearance

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -155,7 +155,7 @@ function showWarn(id, text){
             removeWarn();
         } else {
             missCount++;
-            if (missCount >= 2 && !document.querySelector('.sceneguard-warn')) {
+            if (missCount >= 2) {
                 showWarn(id, '⚠ Scene list stale — resend with setScene.');
             }
         }


### PR DESCRIPTION
## Summary
- show SceneGuard warning after 2 invalid turns regardless of existing bubbles

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a4b11e6848322bbfdb4830e0d62d1