### PR TITLE
Remove unused lastHadScene variable

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -35,7 +35,6 @@ const inject = window.SillyTavern?.injectAssistant
     ctx.extensionSettings.features ??= {};
     ctx.extensionSettings.features.sceneguard ??= { enabled: true };
     const settings = ctx.extensionSettings.features.sceneguard;
-    let lastHadScene = true;
     let errorNode = null;
 
     function canon(id){
@@ -159,7 +158,6 @@ function showWarn(id, text){
                 showWarn(id, '⚠ Scene list stale — resend with setScene.');
             }
         }
-        lastHadScene = foundScene;
     }
 
 


### PR DESCRIPTION
## Summary
- clean up unused tracking in scene-guard extension

## Testing
- `node --check public/scripts/extensions/scene-guard/index.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a4bdbabb883229502f132c1b11e8a