### PR TITLE
Add fallback color for scene-guard warning

### DIFF
--- a/public/scripts/extensions/scene-guard/style.css
+++ b/public/scripts/extensions/scene-guard/style.css
@@ -1,5 +1,6 @@
 .system-bubble.sceneguard-warn {
-    color: var(--warning);
+    /* Fallback to red if --warning isn't defined */
+    color: var(--warning, red);
     font-style: italic;
     display: block;
     margin: 4px 0;


### PR DESCRIPTION
## Summary
- ensure warning text for the Scene Guard extension stays visible by adding a CSS variable fallback

## Testing
- `npm --prefix tests test` *(fails: jest not found)*
- `npm run lint` *(fails: 75 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683a4d451a348322a04fe4c97cf2af15