### PR TITLE
Add chat change listener to SceneGuard

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -214,6 +214,10 @@ missCount = 0;  // start the streak from scratch
     function init(){
         const chatBox = document.getElementById('chat');
         window.addEventListener('stateReset', () => { missCount = 0; removeWarn(); });
+        eventSource.on(event_types.CHAT_CHANGED, () => {
+            missCount = 0;
+            removeWarn();
+        });
         if(chatBox){
             new MutationObserver(muts => {
                 muts.forEach(m => {


### PR DESCRIPTION
## Summary
- add a listener for `event_types.CHAT_CHANGED` to clear SceneGuard warnings

## Testing
- `npm run lint` *(fails: 75 errors)*
- `cd tests && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a54b952a48322920a038c8b67f552