### PR TITLE
Fix Tagger self-test scene setup

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -482,6 +482,7 @@ async function runSelfTest(){
         step++;
 
         /* 15 – stop-words filtered */
+        CoreState.setScene([canon('CookingPot'), canon('WoodenTable')]);
         const base = document.querySelectorAll('.rpg-item').length;
         injectAssistant('A battered cooking pot sits on the wooden table.');
         await tick();


### PR DESCRIPTION
## Summary
- ensure Tagger self-test sets CookingPot and WoodenTable before step 15

## Testing
- `npm run lint` *(fails: 42 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683aa3e3b0bc8322a23eeef2b1edcd09