### PR TITLE
Fix fuzzyHighlightElement scanning

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -196,9 +196,10 @@ function fuzzyHighlightElement(el){
         },
     });
     const done = new Set();
-    for(let node = walker.nextNode(); node; node = walker.nextNode()){
+    for(let node = walker.nextNode(); node;){
         const text = node.nodeValue;
         const spans = [...ngramSpans(text)];
+        let replaced = false;
         for(const span of spans){
             let clean = stripAdj(span.text.toLowerCase());
             if(!clean) continue;
@@ -226,17 +227,24 @@ function fuzzyHighlightElement(el){
             }
             if(id){
                 const frag = document.createDocumentFragment();
-                frag.appendChild(document.createTextNode(text.slice(0,span.start)));
+                frag.appendChild(document.createTextNode(text.slice(0, span.start)));
                 const sp = document.createElement('span');
                 sp.className = 'rpg-item scene';
                 sp.dataset.itemId = id;
-                sp.textContent = text.slice(span.start,span.end);
+                sp.textContent = text.slice(span.start, span.end);
                 frag.appendChild(sp);
-                frag.appendChild(document.createTextNode(text.slice(span.end)));
+                const after = document.createTextNode(text.slice(span.end));
+                frag.appendChild(after);
                 node.replaceWith(frag);
                 done.add(id);
+                walker.currentNode = after;
+                node = after;
+                replaced = true;
                 break;
             }
+        }
+        if(!replaced){
+            node = walker.nextNode();
         }
     }
 }


### PR DESCRIPTION
## Summary
- continue scanning text nodes after first highlight

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 42 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683aa7103b2c8322a02837e3051bed89