### PR TITLE
Update hidden message queries

### DIFF
--- a/public/scripts/extensions/scene-guard/index.js
+++ b/public/scripts/extensions/scene-guard/index.js
@@ -113,8 +113,7 @@ function showWarn(id, text){
         if(!id) return;
         const msg = ctx.chat?.[id];
         if(!msg || msg.is_user || msg.is_system) return;
-        const hiddenNodes = [...node.querySelectorAll('.mes_text div[style]')]
-                    .filter(el => el.style.display === 'none');
+        const hiddenNodes = [...node.querySelectorAll('.mes_text div[hidden]')];
         const hasCtrl = hiddenNodes.some(d => /::\s*setScene/i.test(d.textContent));
         const hidden = hiddenNodes.map(n=>n.textContent.trim()).reverse().find(t => /::\s*setScene/i.test(t));
         let foundScene = false;
@@ -123,9 +122,8 @@ function showWarn(id, text){
         let search = '';
         if(hidden || pendingItems.length){
             const clone = node.cloneNode(true);
-            hiddenNodes.forEach(n => {
-                const target = Array.from(clone.querySelectorAll('div[style]'))
-                    .find(el => el.style.display === 'none');
+            hiddenNodes.forEach(() => {
+                const target = clone.querySelector('div[hidden]');
                 if (target) target.remove();
             });
             search = stripHtml(clone.innerHTML);
@@ -188,7 +186,7 @@ function showWarn(id, text){
 
         const sendTurn = (hidden, visible) => {
             inject(
-                `<div style="display:none">${hidden}</div>${visible}`,
+                `<div hidden>${hidden}</div>${visible}`,
                 { name: 'SelfTest', italic: true }
             );
         };

--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -537,7 +537,7 @@ async function runSelfTest(){
             '::obj id=HeavyDoor name="oak door" carryReq=18',
             '::setScene CookingPot HeavyDoor',
         ];
-        const hidden = cmds.map(c => `<div style="display:none">${c}</div>`).join('');
+        const hidden = cmds.map(c => `<div hidden>${c}</div>`).join('');
         const packet = hidden + 'You lift the cooking pot but the oak door won\u2019t budge.';
         const mid = injectAssistant(packet);
         await tick();
@@ -583,8 +583,7 @@ async function runSelfTest(){
                 if(!node.classList?.contains('mes')) return;
                 if(node.getAttribute('is_user') === 'true') return;
                 const tgt = node.querySelector('.mes_text') || node;
-                const hiddenLines = [...tgt.querySelectorAll('div[style]')]
-                    .filter(el => el.style.display === 'none')
+                const hiddenLines = [...tgt.querySelectorAll('div[hidden]')]
                     .map(n => n.textContent.trim());
                 if(hiddenLines.length){
                     const objs = [];


### PR DESCRIPTION
## Summary
- keep Tagger commands hidden from DOMPurify
- ensure SceneGuard recognizes hidden commands

## Testing
- `npm run lint` *(fails: 40 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683b38b374048322834e366a22ab3041