### PR TITLE
Fix dropItem inventory handling

### DIFF
--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -161,7 +161,11 @@ function addSceneItem(item){
 
 function dropItem(target, item){
     const id = canon(item);
-    CoreState.removeItem(target, id);
+    const removed = removeInventoryItem(target, id);
+    if(!removed){
+        unknownItem(item);
+        return;
+    }
     addSceneItem(id);
 }
 


### PR DESCRIPTION
## Summary
- use helper `removeInventoryItem` in RuleVault `dropItem`
- show `Unknown item` message when item isn't found

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_683b4adae4548322a67d21494ed2f2b9