### PR TITLE
Modify aliasReady check for Tagger

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -621,7 +621,9 @@ async function runSelfTest(){
                         }
                     }
                 }
-                if(!aliasReady) return;
+                // Highlights can be applied while aliasReady is false, so don't
+                // exit early when the next alias map hasn't finished building.
+                // if(!aliasReady) return;
                 setTimeout(() => {
                     autoBracket(tgt);
                     tagElement(tgt);


### PR DESCRIPTION
## Summary
- allow message highlighting before alias map generation finishes by commenting out the `aliasReady` return check in the Tagger MutationObserver

## Testing
- `npm test --prefix tests` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b95f4bb288322adf5977e91824a7f