### PR TITLE
Handle queued highlights during alias map swap

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -188,6 +188,7 @@ function nearMatch(a,b){
 let aliasMapCurrent = {};
 let aliasMapNext = {};
 let aliasReady = true;
+const pendingNodes = new Set();
 let cachedSynonyms = {};
 let doneIds = new Set();
 
@@ -619,6 +620,9 @@ async function runSelfTest(){
                 if(!node.classList?.contains('mes')) return;
                 if(node.getAttribute('is_user') === 'true') return;
                 const tgt = node.querySelector('.mes_text') || node;
+                if(!aliasReady){
+                    pendingNodes.add(node);
+                }
                 const hiddenLines = [...tgt.querySelectorAll('div[hidden]')]
                     .map(n => n.textContent.trim());
                 if(hiddenLines.length){
@@ -640,6 +644,12 @@ async function runSelfTest(){
                                 requestIdleCallback(() => {
                                     aliasMapCurrent = aliasMapNext;
                                     aliasReady = true;
+
+                                    for(const n of pendingNodes){
+                                        reScanMessage(n);
+                                    }
+                                    pendingNodes.clear();
+
                                     reScanMessage(node);
                                 });
                                 // return; // allow highlight pass before alias map completes


### PR DESCRIPTION
## Summary
- track nodes added while alias map is rebuilding
- rescan queued nodes once new alias map is ready

## Testing
- `npm run lint` *(fails: no-unused-vars, spacing, indentation, eol-last)*
- `npm test --prefix tests` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bb1113ce08322b6c1d3c09f584137