### PR TITLE
Filter invalid rpg-item spans

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -668,6 +668,22 @@ async function runSelfTest(){
                             aliasMapCurrent = aliasMapNext;
                             aliasReady = true;
 
+                            const lookup = {};
+                            for(const info of Object.values(aliasMapCurrent)){
+                                const id = info.id;
+                                if(!id) continue;
+                                const req = Number(info.carryReq) || 0;
+                                lookup[id] = Math.max(lookup[id] || 0, req);
+                            }
+                            const playerSTR = CoreState?.stats?.strength ?? 10;
+                            document.querySelectorAll('.rpg-item').forEach(sp => {
+                                const id = sp.dataset.itemId;
+                                const req = lookup[id];
+                                if(req === undefined || playerSTR < req){
+                                    sp.replaceWith(document.createTextNode(sp.textContent || ''));
+                                }
+                            });
+
                             for(const n of pendingNodes){
                                 reScanMessage(n);
                             }


### PR DESCRIPTION
## Summary
- remove rpg-item spans that no longer exist in alias map or exceed STR requirement when alias map refreshes

## Testing
- `npm run lint` *(fails: several unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683bb599438c83229b5e3a6e12155a4e