### PR TITLE
Fix tagger early exit when alias map not ready

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -623,7 +623,6 @@ async function runSelfTest(){
                 if(!node.classList?.contains('mes')) return;
                 if(node.getAttribute('is_user') === 'true') return;
                 const tgt = node.querySelector('.mes_text') || node;
-                let skipHighlight = !aliasReady;
                 if(!aliasReady){
                     pendingNodes.add(node);
                 }
@@ -669,7 +668,6 @@ async function runSelfTest(){
                         cachedSynonyms = {};
                         aliasReady = false;
                         pendingNodes.add(node);
-                        skipHighlight = true;
                         requestIdleCallback(() => {
                             aliasMapCurrent = aliasMapNext;
                             aliasReady = true;
@@ -705,9 +703,10 @@ async function runSelfTest(){
                 // Highlights can be applied while aliasReady is false, so don't
                 // exit early when the next alias map hasn't finished building.
                 // if(!aliasReady) return;
-                if(skipHighlight){
+                if (!aliasReady) {
+                    pendingNodes.add(node);        // queue for later rescan
                     console.log('[Tagger] queued node while aliasReady=false →', node.dataset?.mesid);
-                    return;
+                    return;                        // ← HARD EXIT – do NOT schedule quick pass
                 }
                 setTimeout(() => {
                     console.log('[Tagger] highlight pass with map keys:', Object.keys(aliasMapCurrent));


### PR DESCRIPTION
## Summary
- ensure Tagger doesn't schedule highlight when alias map is rebuilding

## Testing
- `npm run lint` *(fails: 42 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683bc0c0cdc88322994a292c4060e441