### PR TITLE
Persist initial core state

### DIFF
--- a/public/scripts/extensions/core-state/index.js
+++ b/public/scripts/extensions/core-state/index.js
@@ -183,6 +183,9 @@ window['CoreState'] = {
     setDefaultMaxHp,
 };
 
+// Persist the initial state for the current chat
+persist();
+
 /* ===============================================================
    Dev smoke test – paste into browser console after reload
 ================================================================ */


### PR DESCRIPTION
## Summary
- invoke `persist()` at the end of core-state extension to save initial data

## Testing
- `npm run lint` *(fails: no-unused-vars and other errors)*
- `npm test --prefix tests` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bcdfbddb883228eab027b07bd101b