### PR TITLE
Add level and XP display to HUD panel

### DIFF
--- a/public/scripts/extensions/hud-panel/hud-panel.css
+++ b/public/scripts/extensions/hud-panel/hud-panel.css
@@ -8,8 +8,8 @@
   border-radius:4px;
   color:#eee;
   font-size:13px;
-  width:180px;
-  max-width:180px;
+  width:220px;
+  max-width:220px;
   max-height:60vh;
   overflow-y:auto;
 }
@@ -20,3 +20,7 @@
 @keyframes dmgflash{0%{background:#a00;}100%{background:inherit;}}
 .hud-panel .hud-bar{position:relative;margin:2px 0;}
 .hud-panel .hud-value{position:absolute;left:0;top:0;width:100%;text-align:center;font-size:12px;pointer-events:none;color:#fff;}
+.hud-panel .hud-lvxp{display:flex;align-items:center;gap:4px;margin:2px 0;}
+.hud-panel .hud-lv{white-space:nowrap;font-weight:bold;}
+.hud-panel .hud-xp{flex:1;}
+.hud-panel .hud-stats{margin:2px 0;font-size:12px;}

--- a/public/scripts/extensions/hud-panel/index.js
+++ b/public/scripts/extensions/hud-panel/index.js
@@ -61,6 +61,8 @@ function createPanel() {
     div.innerHTML = `
         <img class="hud-avatar">
         <div class="hud-name"></div>
+        <div class="hud-lvxp"><span class="hud-lv"></span><progress class="hud-xp" max="0" value="0"></progress></div>
+        <div class="hud-stats"></div>
         <div class="hud-bar"><progress class="hud-hp" max="100" value="0"></progress><div class="hud-value hud-hp-value"></div></div>
         <div class="hud-bar"><progress class="hud-mp" max="100" value="0"></progress><div class="hud-value hud-mp-value"></div></div>
         <details class="hud-scene"><summary>Scene Objects (0)</summary><ul></ul></details>
@@ -94,6 +96,21 @@ function updatePanel(div) {
     const state = rootState.characters?.[CoreState.playerName] || {};
     div.querySelector('.hud-avatar').src = getUserAvatar(user_avatar);
     div.querySelector('.hud-name').textContent = name1;
+    const lvSpan = div.querySelector('.hud-lv');
+    const xpProg = div.querySelector('.hud-xp');
+    if (lvSpan) lvSpan.textContent = `Lv ${state.level ?? 0}`;
+    if (xpProg) {
+        xpProg.max = state.max_xp || state.xp_max || 0;
+        xpProg.value = state.xp || 0;
+    }
+    const statsDiv = div.querySelector('.hud-stats');
+    if (statsDiv) {
+        const str = state.str ?? state.STR ?? 0;
+        const dex = state.dex ?? state.DEX ?? 0;
+        const vit = state.vit ?? state.VIT ?? 0;
+        const mind = state.mind ?? state.MIND ?? 0;
+        statsDiv.textContent = `STR ${str}  DEX ${dex}  VIT ${vit}  MIND ${mind}`;
+    }
     const hp = div.querySelector('.hud-hp');
     const hpVal = div.querySelector('.hud-hp-value');
     if (hp) {


### PR DESCRIPTION
## Summary
- add level/XP display and stats row to the HUD panel
- show values from state when updating the panel
- widen the HUD panel and style the new rows

## Testing
- `npm test --prefix tests` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bf55a9bc88322948be3c569c7fb94