### PR TITLE
Fix core-state persistence on page unload

### DIFF
--- a/public/scripts/extensions/core-state/index.js
+++ b/public/scripts/extensions/core-state/index.js
@@ -1,4 +1,4 @@
-import { debounce } from '../../utils.js';
+import { debounce, cancelDebounce } from '../../utils.js';
 import {
     chat,
     addOneMessage,
@@ -383,6 +383,12 @@ function onChatChanged() {
 }
 
 eventSource.on(event_types.CHAT_CHANGED, onChatChanged);
+
+// Ensure pending state saves are flushed before the page unloads
+window.addEventListener('beforeunload', () => {
+    cancelDebounce(saveDebounced);
+    persist();
+});
 
 window['getState'] = getState;
 window['getStats'] = getStats;


### PR DESCRIPTION
## Summary
- flush pending debounced save when unloading the page
- import cancelDebounce

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c95890e3c8322a3cded8b1c0cd8bb