### PR TITLE
Update RuleVault enemy commands

### DIFF
--- a/public/scripts/extensions/rulevault/index.js
+++ b/public/scripts/extensions/rulevault/index.js
@@ -256,7 +256,11 @@ function handleCommand(cmd){
         const target = cmd.args.target || personaName();
         const amount = parseInt(cmd.args.amount, 10) || 0;
         const reason = cmd.args.reason;
-        CoreState.modHP(target, amount, reason);
+        if(CoreState.getEnemy(target)){
+            CoreState.modEnemyHP(target, amount);
+        }else{
+            CoreState.modHP(target, amount, reason);
+        }
     }else if(cmd.verb  ===  'modMP'){
         const target = cmd.args.target || personaName();
         const amount = parseInt(cmd.args.amount, 10) || 0;
@@ -265,6 +269,11 @@ function handleCommand(cmd){
         const target = cmd.args.target || personaName();
         const amount = parseInt(cmd.args.amount, 10) || 0;
         CoreState.addXP(target, amount);
+    }else if(cmd.verb  ===  'spawn'){
+        CoreState.spawnEnemy(cmd.args);
+        // TODO: SceneGuard cross-checks (phase-2)
+    }else if(cmd.verb  ===  'despawn'){
+        if(cmd.args.id) CoreState.despawnEnemy(cmd.args.id);
     }else if(cmd.verb  ===  'dropItem'){
         if(cmd.args.item){
             const target = cmd.args.target || personaName();


### PR DESCRIPTION
## Summary
- extend RuleVault `handleCommand` to support enemy spawn/despawn
- improve modHP to target enemies when applicable
- add TODO on future SceneGuard cross-checks

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683cda55e5e48322811864e5bc46b44e