### PR TITLE
Clarify XP table usage

### DIFF
--- a/public/scripts/extensions/core-state/index.js
+++ b/public/scripts/extensions/core-state/index.js
@@ -44,6 +44,9 @@ const inject = globalThis.SillyTavern?.injectAssistant
 const xpNeeded = lvl => lvl * 100;
 
 // TODO: move this XP table to external JSON defaults
+// Player level progression still relies on xpNeeded(level) = level * 100.
+// The values below are only used for enemy reward amounts and do not
+// influence how a character levels up.
 export const ENEMY_XP = { E: 10, D: 25, C: 60, B: 120, A: 250, S: 500 };
 
 function blankChar() {


### PR DESCRIPTION
## Summary
- document how player XP uses `xpNeeded(level) = level * 100`
- note enemy XP rewards are independent

## Testing
- `npm run lint` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683cdebffd4883228b63e7f32cd2a004