### PR TITLE
Fix spawnEnemy HP parsing

### DIFF
--- a/public/scripts/extensions/core-state/index.js
+++ b/public/scripts/extensions/core-state/index.js
@@ -348,7 +348,9 @@ export function removeItem(target, itemId) {
 
 export function spawnEnemy({ id, name, tier = 'E', hp = 1, portrait = null }) {
     if (!id) return;
-    state.enemies[id] = { id, name, tier, hp, portrait };
+    hp = parseInt(hp, 10) || 0;
+    tier = String(tier || '').toUpperCase();
+    state.enemies[id] = { id, name, tier, hp, maxHP: hp, portrait, abilities: [] };
     saveDebounced();
     // TODO: portrait handling and HUD integration
     window.dispatchEvent(new CustomEvent('enemySpawn', { detail: { ...state.enemies[id] } }));


### PR DESCRIPTION
## Summary
- ensure spawnEnemy parses hp as integer
- store `maxHP` and initialize enemy abilities
- normalize tier values to uppercase

## Testing
- `npm run lint` *(fails: parse errors etc.)*
- `node test-enemyFlowSelfTest.js` *(fails: Named export 'toggle' not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ce9989fd08322b6fe42096e37552b