### PR TITLE
Add enemies list to HUD panel

### DIFF
--- a/public/scripts/extensions/hud-panel/hud-panel.css
+++ b/public/scripts/extensions/hud-panel/hud-panel.css
@@ -24,3 +24,4 @@
 .hud-panel .hud-lv{white-space:nowrap;font-weight:bold;}
 .hud-panel .hud-xp{flex:1;}
 .hud-panel .hud-stats{margin:2px 0;font-size:12px;}
+.hud-foes{margin-top:4px;}

--- a/public/scripts/extensions/hud-panel/index.js
+++ b/public/scripts/extensions/hud-panel/index.js
@@ -66,7 +66,8 @@ function createPanel() {
         <div class="hud-bar"><progress class="hud-hp" max="100" value="0"></progress><div class="hud-value hud-hp-value"></div></div>
         <div class="hud-bar"><progress class="hud-mp" max="100" value="0"></progress><div class="hud-value hud-mp-value"></div></div>
         <details class="hud-scene"><summary>Scene Objects (0)</summary><ul></ul></details>
-        <details class="hud-inv"><summary>Inventory (0)</summary><ul></ul></details>`;
+        <details class="hud-inv"><summary>Inventory (0)</summary><ul></ul></details>
+        <details class="hud-foes"><summary>Enemies (0)</summary><ul></ul></details>`;
     document.body.prepend(div);
     makeDraggable(div);
     return div;
@@ -89,6 +90,29 @@ function renderSceneObjects(arr = []) {
         sceneUl.appendChild(li);
     });
     sceneSum.textContent = `Scene Objects (${arr.length})`;
+}
+
+function renderEnemies(map = {}) {
+    const foeUl = document.querySelector('.hud-panel .hud-foes ul');
+    const foeSum = document.querySelector('.hud-panel .hud-foes summary');
+    if (!foeUl || !foeSum) return;
+    foeUl.innerHTML = '';
+    const arr = Object.values(map);
+    if (arr.length === 0) {
+        foeUl.style.display = 'none';
+        foeSum.textContent = 'Enemies (0)';
+        return;
+    }
+    foeUl.style.display = '';
+    arr.forEach(e => {
+        const li = document.createElement('li');
+        const name = e.name || e.id;
+        const hp = e.hp ?? 0;
+        const max = e.maxHP ?? e.max_hp ?? 0;
+        li.textContent = `${name} \u2013 ${hp} / ${max} HP`;
+        foeUl.appendChild(li);
+    });
+    foeSum.textContent = `Enemies (${arr.length})`;
 }
 
 function updatePanel(div) {
@@ -137,6 +161,7 @@ function updatePanel(div) {
         invSum.textContent = `Inventory (${(state.inventory || []).length})`;
     }
     renderSceneObjects(rootState.sceneObjects || []);
+    renderEnemies(rootState.enemies || {});
 }
 
 export function init() {
@@ -156,6 +181,8 @@ export function init() {
     window.addEventListener('sceneUpdate', e => {
         renderSceneObjects(e.detail.items);
     });
+    ['enemySpawn','enemyHPChange','enemyDespawn'].forEach(ev =>
+        window.addEventListener(ev, () => updatePanel(panel)));
     globalThis.HUDPanel = { element: panel, update: () => updatePanel(panel) };
 }
 
@@ -174,4 +201,7 @@ setScene(['Torch','Key']);
 → HUD shows 2 scene objects.
 setScene(['Ruby']);
 → HUD updates to 1 scene object.
+spawnEnemy({id:'Dummy',name:'Dummy',tier:'E',hp:10,maxHP:10});
+modEnemyHP('Dummy',-5);  → HUD updates to 5/10
+modEnemyHP('Dummy',-6);  → Dummy vanishes, count drops to 0
 */


### PR DESCRIPTION
## Summary
- extend HUD panel to show live enemies from `CoreState.state.enemies`
- render enemy status like `name – hp / maxHP` and update on enemy events
- wire up listeners for enemySpawn/enemyHPChange/enemyDespawn
- small CSS margin rule for `.hud-foes`
- add dev smoke test comments

## Testing
- `npm --prefix tests test --silent` *(fails: `jest: not found`)*
- `npm run lint --silent` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_683cf0831e548322adb8db7d35d31ff3