### PR TITLE
Observe only chat container in tagger

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -600,6 +600,7 @@ async function runSelfTest(){
     window.addEventListener('itemAdd', recolorAll);
     window.addEventListener('itemRemove', recolorAll);
     window.addEventListener('stateReset', () => { cachedSynonyms = new Map(); refreshAliasMap(); recolorAll(); });
+    const chatContainer = document.getElementById('chat');
     new MutationObserver(muts=>{
         muts.forEach(m=>{
             m.addedNodes.forEach(node=>{
@@ -643,7 +644,7 @@ async function runSelfTest(){
                 }, 0);
             });
         });
-    }).observe(document.body,{ childList:true,subtree:true });
+    }).observe(chatContainer,{ childList:true });
     SlashCommandParser.addCommandObject(SlashCommand.fromProps({
         name:'tagger-selftest',
         callback: runSelfTest,


### PR DESCRIPTION
## Summary
- limit tagger's MutationObserver to the `#chat` element so DOM updates outside the chat log aren't rescanned

## Testing
- `npm run lint` *(fails: parseItems defined but never used and other eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683cfce602ec832290a31619fe48d53d