### PR TITLE
Add enemy aliases to tagger

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -121,6 +121,30 @@ function buildAliasMap(objs = []){
             if(!map[a]) map[a] = { id, carryReq };
         }
     }
+
+    // include enemies in alias map
+    for(const enemy of Object.values(CoreState.getState().enemies || {})){
+        const id = canon(enemy.id);
+        if(!id) continue;
+        const aliasSet = new Set();
+        for(const raw of [enemy.id, enemy.name]){
+            if(!raw) continue;
+            const tokens = splitCanonicalTokens(raw);
+            const phrase = tokens.join(' ').toLowerCase();
+            const last = tokens[tokens.length - 1];
+            if(phrase){
+                aliasSet.add(phrase);
+                aliasSet.add(phrase.replace(/\s+/g,''));
+            }
+            if(last && last.length >= 4 && !STOP_SINGLE.includes(last)){
+                aliasSet.add(last.toLowerCase());
+            }
+        }
+        aliasSet.add(id.toLowerCase());
+        for(const a of aliasSet){
+            if(!map[a]) map[a] = { id, type: 'enemy' };
+        }
+    }
     return map;
 }
 


### PR DESCRIPTION
## Summary
- support tagging enemies in buildAliasMap

## Testing
- `npm run lint` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683d2cb70bdc8322b0f696411eeb81e7