### PR TITLE
Update fuzzy highlight class handling

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -313,7 +313,8 @@ function fuzzyHighlightElement(el){
                 range.setStart(node, span.start);
                 range.setEnd(node, span.end);
                 const sp = document.createElement('span');
-                sp.className = 'rpg-item scene';
+                const cls = obj.type === 'enemy' ? 'tag-enemy' : 'scene';
+                sp.className = `rpg-item ${cls}`;
                 sp.dataset.itemId = obj.id;
                 range.surroundContents(sp);
                 doneIds.add(obj.id);


### PR DESCRIPTION
## Summary
- highlight enemies differently in tagger's fuzzy matcher

## Testing
- `npm run lint` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683d2f2c3b988322a3ffb8bf21b8595b