### PR TITLE
Add enemy tag style

### DIFF
--- a/public/scripts/extensions/tagger/tagger.css
+++ b/public/scripts/extensions/tagger/tagger.css
@@ -2,3 +2,5 @@
 .rpg-item.inv    { color:#8f8; }
 .rpg-item.scene  { color:#bbb; }
 .rpg-item.unknown{ color:#f88; }
+
+.tag-enemy { color:#ff6666; font-weight:600; cursor:help; }


### PR DESCRIPTION
## Summary
- add `.tag-enemy` style to tagger extension

## Testing
- `npm --prefix tests test` *(fails: jest not found)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683d310c63188322afa5a204436faaeb