### PR TITLE
Update Tagger to refresh alias map on enemy events

### DIFF
--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -647,6 +647,14 @@ async function runSelfTest(){
         highlightAll(true);
         recolorAll();
     });
+    window.addEventListener('enemySpawn', () => {
+        refreshAliasMap();
+        highlightAll(true);
+    });
+    window.addEventListener('enemyDespawn', () => {
+        refreshAliasMap();
+        highlightAll(true);
+    });
     window.addEventListener('itemAdd', () => { recolorAll(); });
     window.addEventListener('itemRemove', () => { recolorAll(); });
     window.addEventListener('stateReset', () => {


### PR DESCRIPTION
## Summary
- refresh alias map when enemies spawn or despawn to keep tagger highlights up to date

## Testing
- `npm test --prefix tests` *(fails: jest: not found)*
- `npm run lint` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683d32ebc7cc8322a13bc4f0f82f91aa