### PR TITLE
Add companion HUD and state snapshot

### DIFF
--- a/public/scripts/extensions/core-state/index.js
+++ b/public/scripts/extensions/core-state/index.js
@@ -5,6 +5,9 @@ import {
     eventSource,
     event_types,
     system_message_types,
+    setExtensionPrompt,
+    extension_prompt_roles,
+    extension_prompt_types,
 } from '../../../script.js';
 import { getContext } from '../../extensions.js';
 import { SlashCommandParser } from '../../slash-commands/SlashCommandParser.js';
@@ -49,8 +52,11 @@ const xpNeeded = lvl => lvl * 100;
 // influence how a character levels up.
 export const ENEMY_XP = { E: 10, D: 25, C: 60, B: 120, A: 250, S: 500 };
 
-function blankChar() {
+function blankChar(name = '') {
     const c = {
+        name,
+        portrait: null,
+        abilities: [],
         inventory: [],
         buffs: {},
         str: 0,
@@ -203,13 +209,26 @@ const saveDebounced = debounce(persist, 250);
 
 function ensureChar(target) {
     const name = target || playerName;
-    if (!state.characters[name]) state.characters[name] = blankChar();
+    if (!state.characters[name]) state.characters[name] = blankChar(name);
     return name;
 }
 
 export function getState(target) {
     if (target) return JSON.parse(JSON.stringify(state.characters[target] || {}));
     return JSON.parse(JSON.stringify(state));
+}
+
+export function getCompanionSnapshot(target) {
+    const root = getState();
+    const char = root.characters?.[target] || {};
+    const scene = (root.sceneObjects || []).join(', ');
+    const inv = (char.inventory || []).join(', ');
+    const abil = (char.abilities || []).join(', ');
+    const lines = [];
+    if (scene) lines.push(`Scene Objects: ${scene}`);
+    if (inv) lines.push(`Inventory: ${inv}`);
+    if (abil) lines.push(`Abilities: ${abil}`);
+    return lines.join('\n');
 }
 
 export function getStats(target) {
@@ -449,6 +468,11 @@ function onChatChanged() {
 }
 
 eventSource.on(event_types.CHAT_CHANGED, onChatChanged);
+eventSource.on(event_types.GROUP_MEMBER_DRAFTED, (id) => {
+    if (id === playerName) return;
+    const snap = getCompanionSnapshot(id);
+    setExtensionPrompt(`corestate-${id}`, snap, extension_prompt_types.IN_PROMPT, 0, false, extension_prompt_roles.SYSTEM);
+});
 
 // Ensure pending state saves are flushed before the page unloads
 window.addEventListener('beforeunload', () => {
@@ -487,6 +511,7 @@ window['CoreState'] = {
     grantXPFromTier,
     clearState,
     snapshot,
+    getCompanionSnapshot,
     runSelfTest,
 };
 

--- a/public/scripts/extensions/hud-panel/hud-panel.css
+++ b/public/scripts/extensions/hud-panel/hud-panel.css
@@ -25,3 +25,7 @@
 .hud-panel .hud-xp{flex:1;}
 .hud-panel .hud-stats{margin:2px 0;font-size:12px;}
 .hud-foes{margin-top:4px;}
+.hud-companions{margin-top:6px;}
+.companion-card{background:#333;padding:4px;border-radius:4px;margin-top:4px;font-size:12px;}
+.companion-card .comp-name{font-weight:bold;margin:2px 0;word-break:break-word;}
+.hud-companions img{width:100%;border-radius:4px;}

--- a/public/scripts/extensions/hud-panel/index.js
+++ b/public/scripts/extensions/hud-panel/index.js
@@ -67,7 +67,8 @@ function createPanel() {
         <div class="hud-bar"><progress class="hud-mp" max="100" value="0"></progress><div class="hud-value hud-mp-value"></div></div>
         <details class="hud-scene"><summary>Scene Objects (0)</summary><ul></ul></details>
         <details class="hud-inv"><summary>Inventory (0)</summary><ul></ul></details>
-        <details class="hud-foes"><summary>Enemies (0)</summary><ul></ul></details>`;
+        <details class="hud-foes"><summary>Enemies (0)</summary><ul></ul></details>
+        <div class="hud-companions"></div>`;
     document.body.prepend(div);
     makeDraggable(div);
     return div;
@@ -113,6 +114,63 @@ function renderEnemies(map = {}) {
         foeUl.appendChild(li);
     });
     foeSum.textContent = `Enemies (${arr.length})`;
+}
+
+function createCompanionCard(name) {
+    const card = document.createElement('div');
+    card.className = 'companion-card';
+    card.dataset.name = name;
+    card.innerHTML = `
+        <img class="comp-avatar">
+        <div class="comp-name"></div>
+        <div class="hud-bar"><progress class="comp-hp" max="100" value="0"></progress><div class="hud-value comp-hp-value"></div></div>
+        <details class="comp-inv"><summary>Inventory (0)</summary><ul></ul></details>`;
+    return card;
+}
+
+function updateCompanionCard(card, state) {
+    card.querySelector('.comp-avatar').src = state.portrait || '';
+    card.querySelector('.comp-name').textContent = state.name || card.dataset.name;
+    const hp = card.querySelector('.comp-hp');
+    const hpVal = card.querySelector('.comp-hp-value');
+    if (hp) {
+        hp.max = state.max_hp || 0;
+        hp.value = state.hp || 0;
+        hpVal.textContent = `${state.hp ?? 0} / ${state.max_hp ?? 0}`;
+    }
+    const invUl = card.querySelector('.comp-inv ul');
+    const invSum = card.querySelector('.comp-inv summary');
+    if (invUl && invSum) {
+        invUl.innerHTML = '';
+        (state.inventory || []).forEach(it => {
+            const li = document.createElement('li');
+            li.textContent = it;
+            invUl.appendChild(li);
+        });
+        invSum.textContent = `Inventory (${(state.inventory || []).length})`;
+    }
+}
+
+function renderCompanions(div, characters) {
+    const container = div.querySelector('.hud-companions');
+    if (!container) return;
+    const names = Object.keys(characters).filter(n => n !== CoreState.playerName);
+    const existing = [...container.querySelectorAll('.companion-card')].map(c => c.dataset.name);
+    for (const name of existing) {
+        if (!names.includes(name)) {
+            const node = container.querySelector(`.companion-card[data-name="${name}"]`);
+            if (node) node.remove();
+        }
+    }
+    for (const name of names) {
+        const state = characters[name] || {};
+        let card = container.querySelector(`.companion-card[data-name="${name}"]`);
+        if (!card) {
+            card = createCompanionCard(name);
+            container.appendChild(card);
+        }
+        updateCompanionCard(card, state);
+    }
 }
 
 function updatePanel(div) {
@@ -162,6 +220,7 @@ function updatePanel(div) {
     }
     renderSceneObjects(rootState.sceneObjects || []);
     renderEnemies(rootState.enemies || {});
+    renderCompanions(div, rootState.characters || {});
 }
 
 export function init() {


### PR DESCRIPTION
## Summary
- extend core-state to track companion info and provide read-only snapshots
- inject companion snapshot when NPCs take a turn
- render companion cards in the HUD panel
- style companion HUD elements

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_683d31e3b5488322ba1ce54335ef37ce