### PR TITLE
Improve Tagger performance

### DIFF
--- a/public/scripts/extensions/tagger/README.md
+++ b/public/scripts/extensions/tagger/README.md
@@ -1,0 +1,9 @@
+# Tagger Extension
+
+This extension automatically highlights scene objects and inventory items in chat messages.
+
+## Settings
+
+### `maxRescan`
+Controls how many recent messages are rescanned when new messages arrive. Lower values (for example `5`) may reduce lag when very long chats are loaded.
+

--- a/public/scripts/extensions/tagger/index.js
+++ b/public/scripts/extensions/tagger/index.js
@@ -8,6 +8,7 @@ const ctx = globalThis.SillyTavern?.getContext?.() ?? {};
 ctx.extensionSettings ??= {};
 ctx.extensionSettings.features ??= {};
 ctx.extensionSettings.features.tagger ??= { enabled: true };
+ctx.extensionSettings.features.tagger.maxRescan ??= 10;
 const settings = ctx.extensionSettings.features.tagger;
 
 function canon(label){
@@ -333,7 +334,8 @@ function fuzzyHighlightElement(el){
 let processedMessageIds = new Set();
 
 function highlightAll(force = false){
-    const messages = document.querySelectorAll('#chat .mes');
+    const allMessages = Array.from(document.querySelectorAll('#chat .mes'));
+    const messages = allMessages.slice(-settings.maxRescan);
     messages.forEach(mes => {
         const mid = mes.getAttribute('mesid');
         if(!mid) return;


### PR DESCRIPTION
## Summary
- configure the tagger extension with a `maxRescan` setting
- rescan only the latest messages when highlighting
- document the new option

## Testing
- `npm run lint` *(fails: 44 errors in tagger/index.js)*

------
https://chatgpt.com/codex/tasks/task_e_683dea99ead883229a14a90bff31de85